### PR TITLE
Add order dependent derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "from_tuple"
 version = "1.0.0"
-authors = ["chip <chip@chip.sh>"]
+authors = ["chip <chip@chip.sh>", "JohnScience <demenev.dmitriy1@gmail.com>"]
 license = "Apache-2.0 OR MIT"
 description = "Derive structs from tuples."
 documentation = "https://docs.rs/from_tuple"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
-quote = "1.0.2"
-syn = { version = "1", features = ["extra-traits"] }
+proc-macro2 = "1.0.36"
+quote = "1.0.15"
+syn = { version = "1.0.2" }
+
+
+[features]
+default = ["unique_fields"]
+unique_fields = ["syn/extra-traits"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "from_tuple"
-version = "0.1.2"
+version = "1.0.0"
 authors = ["chip <chip@chip.sh>"]
 license = "Apache-2.0 OR MIT"
 description = "Derive structs from tuples."
 documentation = "https://docs.rs/from_tuple"
 homepage = "https://docs.rs/from_tuple"
 repository = "https://github.com/chippers/from_tuple"
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true
@@ -19,5 +19,6 @@ syn = { version = "1.0.2" }
 
 
 [features]
-default = ["unique_fields"]
-unique_fields = ["syn/extra-traits"]
+default = ["strictly_heterogeneous", "order_dependent"]
+strictly_heterogeneous = ["syn/extra-traits"]
+order_dependent = ["syn/full", "syn/printing"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # from_tuple
 
-[Derive macros] generating implementations of `core::convert:From<...>` on `struct`s.
+[Derive macros] generating implementations of [`core::convert:From<...>`][`From`] on `struct`s.
 
 Find more information on the documentation pages of [`FromStrictlyHeterogeneousTuple`] and [`OrderDependentFromTuple`].
 
-[`FromStrictlyHeterogeneousTuple`]: https://docs.rs/from_tuple/latest/from_tuple/derive.FromStrictlyHeterogeneousTuple.html
-[`OrderDependentFromTuple`]: https://docs.rs/from_tuple/latest/from_tuple/derive.OrderDependentFromTuple.html
+## Examples
 
-## Example
+* [`FromStrictlyHeterogeneousTuple`]
 
 ```rust
 use from_tuple::FromStrictlyHeterogeneousTuple;
@@ -19,13 +18,36 @@ struct Hello {
     counter: usize
 }
 
-fn main() {
-    let hello: Hello = (-42, "hi".to_string(), 0usize).into();
+let h1: Hello = ("world".into(), -1, 42usize).into();
+assert_eq!(h1.time, -1);
+assert_eq!(h1.counter, 42);
+assert_eq!(&h1.message, "world");
 
-    assert_eq!(&hello.message, "hi");
-    assert_eq!(hello.time, -42);
-    assert_eq!(hello.counter, 0);
+let h2: Hello = (1_000_000_usize, i32::min_value(), "greetings".into()).into();
+assert_eq!(h2.time, i32::min_value());
+assert_eq!(h2.counter, 1_000_000);
+assert_eq!(&h2.message, "greetings");
+
+let h3: Hello = (-42, "hi".into(), 0usize).into();
+assert_eq!(h3.time, -42);
+assert_eq!(h3.counter, 0);
+assert_eq!(&h3.message, "hi");
+```
+
+* [`OrderDependentFromTuple`]
+
+```rust
+use from_tuple::OrderDependentFromTuple;
+
+#[derive(OrderDependentFromTuple)]
+struct Hello {
+    offset: usize,
+    len: usize,
 }
+
+let strukt = Hello::from((234, 16));
+assert_eq!(strukt.offset, 234);
+assert_eq!(strukt.len, 16);
 ```
 
 ## License
@@ -44,3 +66,6 @@ for inclusion in this project by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
 [Derive macros]: https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros
+[`From`]: https://doc.rust-lang.org/nightly/core/convert/trait.From.html
+[`FromStrictlyHeterogeneousTuple`]: https://docs.rs/from_tuple/latest/from_tuple/derive.FromStrictlyHeterogeneousTuple.html
+[`OrderDependentFromTuple`]: https://docs.rs/from_tuple/latest/from_tuple/derive.OrderDependentFromTuple.html

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 # from_tuple
 
-Derive `From` tuples for `struct`s  that have unique field types.  Because all
-field types **must** be unique, it is most useful for `struct`s utilizing the
-[newtype] pattern for its fields.
+[Derive macros] generating implementations of `core::convert:From<...>` on `struct`s.
 
-Find more information on the [`FromTuple` documentation page].
+Find more information on the documentation pages of [`FromStrictlyHeterogeneousTuple`] and [`OrderDependentFromTuple`].
 
-[newtype]: https://doc.rust-lang.org/rust-by-example/generics/new_types.html
-[`FromTuple` documentation page]: https://docs.rs/from_tuple/latest/from_tuple/derive.FromTuple.html
+[`FromStrictlyHeterogeneousTuple`]: https://docs.rs/from_tuple/latest/from_tuple/derive.FromStrictlyHeterogeneousTuple.html
+[`OrderDependentFromTuple`]: https://docs.rs/from_tuple/latest/from_tuple/derive.OrderDependentFromTuple.html
 
 ## Example
 
 ```rust
-use from_tuple::FromTuple;
+use from_tuple::FromStrictlyHeterogeneousTuple;
 
-#[derive(FromTuple)]
+#[derive(FromStrictlyHeterogeneousTuple)]
 struct Hello {
     message: String,
     time: i32,
@@ -44,3 +42,5 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this project by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
+
+[Derive macros]: https://doc.rust-lang.org/reference/procedural-macros.html#derive-macros

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ assert_eq!(strukt.len, 16);
 
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,20 @@ struct Hello {
     counter: usize
 }
 
-let h1: Hello = ("world".into(), -1, 42usize).into();
+let t1: (String,i32,usize) = ("world".into(), -1, 42usize);
+let h1: Hello = t1.into();
 assert_eq!(h1.time, -1);
 assert_eq!(h1.counter, 42);
 assert_eq!(&h1.message, "world");
 
-let h2: Hello = (1_000_000_usize, i32::min_value(), "greetings".into()).into();
+let t2: (usize,i32,String) = (1_000_000_usize, i32::min_value(), "greetings".into());
+let h2: Hello = t2.into();
 assert_eq!(h2.time, i32::min_value());
 assert_eq!(h2.counter, 1_000_000);
 assert_eq!(&h2.message, "greetings");
 
-let h3: Hello = (-42, "hi".into(), 0usize).into();
+let t3: (i32,String,usize) = (-42, "hi".into(), 0usize);
+let h3: Hello = t3.into();
 assert_eq!(h3.time, -42);
 assert_eq!(h3.counter, 0);
 assert_eq!(&h3.message, "hi");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub fn from_strictly_heterogeneous_tuple(input: TokenStream) -> TokenStream {
 }
 
 #[cfg(feature="order_dependent")]
-#[proc_macro_derive(FromTuple)]
+#[proc_macro_derive(OrderDependentFromTuple)]
 pub fn derive_from(item: TokenStream) -> TokenStream {
     use syn::{ItemStruct, Fields, token::Comma};
 
@@ -136,8 +136,8 @@ pub fn derive_from(item: TokenStream) -> TokenStream {
     };
 
     let struct_name = item_struct.ident;
-    let where_clause = item_struct.generics.where_clause.clone();
-    let generics = item_struct.generics;
+    let where_clause = item_struct.generics.where_clause.as_ref();
+    let generics = &item_struct.generics;
     let fields_iter = fields.named.iter();
     let fields_tys_ts = fields_iter.clone()
         .map(|f| f.ty.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,9 @@ use {
 ///    |     ^^^^^^^^^^^^^^
 /// ```
 ///
-/// ### `FromStrictlyHeterogeneousTuple` vs `OrderDependentFromTuple`
+/// ### [`FromStrictlyHeterogeneousTuple`] vs [`OrderDependentFromTuple`]
 ///
-/// Order-dependant fields for structs can be *surprising* behaviour as it may accidentally be broken by adding
+/// Dependence on order of fields in structs can be *surprising* behaviour as it may accidentally be broken by adding
 /// a field in the wrong position unknowingly.
 ///
 /// Requiring unique types may also be *surprising* behaviour, but is able to
@@ -124,6 +124,32 @@ pub fn from_strictly_heterogeneous_tuple(input: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Derives implementation of [`core::convert::From<(T1,T2,...,Tn)>`][core::convert::From] on `struct`s
+/// whose fields' types are `T1,T2,...,Tn`.
+/// 
+/// # Example
+/// 
+/// ```
+/// use from_tuple::OrderDependentFromTuple;
+/// 
+/// #[derive(OrderDependentFromTuple)]
+/// struct Hello {
+///     offset: usize,
+///     len: usize,
+/// }
+/// 
+/// let strukt = Hello::from((234, 16));
+/// assert_eq!(strukt.offset, 234);
+/// assert_eq!(strukt.len, 16);
+/// ```
+/// 
+/// ### [`FromStrictlyHeterogeneousTuple`] vs [`OrderDependentFromTuple`]
+///
+/// Dependence on order of fields in structs can be *surprising* behaviour as it may accidentally be broken by adding
+/// a field in the wrong position unknowingly.
+///
+/// Requiring unique types may also be *surprising* behaviour, but is able to
+/// be caught at compile time easily.
 #[cfg(feature="order_dependent")]
 #[proc_macro_derive(OrderDependentFromTuple)]
 pub fn derive_from(item: TokenStream) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,30 +1,22 @@
 #[doc = include_str!("../README.md")]
-
 #[cfg(any(feature = "strictly_heterogeneous", feature = "order_dependent"))]
-use {
-    proc_macro::TokenStream,
-    quote::quote,
-    syn::parse_macro_input,
-};
+use {proc_macro::TokenStream, quote::quote, syn::parse_macro_input};
 
-#[cfg(feature="order_dependent")]
-use {
-    quote::ToTokens,
-    proc_macro2::TokenStream as TokenStream2,
-};
+#[cfg(feature = "order_dependent")]
+use {proc_macro2::TokenStream as TokenStream2, quote::ToTokens};
 
 #[cfg(feature = "strictly_heterogeneous")]
 mod strictly_heterogeneous;
 
 #[cfg(feature = "strictly_heterogeneous")]
 use {
+    strictly_heterogeneous::{impl_from_tuple, permute, verify_unique_field_types},
     syn::{Data, DeriveInput, Error},
-    strictly_heterogeneous::{impl_from_tuple, permute, verify_unique_field_types}
 };
 
-/// Derives `n!` implementations of [`core::convert::From<...>`][core::convert::From] on `struct`s that have 
+/// Derives `n!` implementations of [`core::convert::From<...>`][core::convert::From] on `struct`s that have
 /// unique field types `T1,T2,...,Tn`.
-/// 
+///
 /// More precisely, derives implementations of [`core::convert::From<...>`][core::convert::From]
 /// for all tuples-permuations of `T1,T2,...,Tn`, such as `(T1,T2,...,Tn-1,Tn)`, `(T1,T2,...,Tn,Tn-1)`,
 /// and so on.
@@ -48,23 +40,20 @@ use {
 ///     counter: usize
 /// }
 ///
-/// fn main() {
-///     let h1: Hello = ("world".into(), -1, 42usize).into();
-///     assert_eq!(h1.time, -1);
-///     assert_eq!(h1.counter, 42);
-///     assert_eq!(&h1.message, "world");
+/// let h1: Hello = ("world".into(), -1, 42usize).into();
+/// assert_eq!(h1.time, -1);
+/// assert_eq!(h1.counter, 42);
+/// assert_eq!(&h1.message, "world");
 ///
-///     let h2: Hello = (1_000_000_usize, i32::min_value(), "greetings".into()).into();
-///     assert_eq!(h2.time, i32::min_value());
-///     assert_eq!(h2.counter, 1_000_000);
-///     assert_eq!(&h2.message, "greetings");
+/// let h2: Hello = (1_000_000_usize, i32::min_value(), "greetings".into()).into();
+/// assert_eq!(h2.time, i32::min_value());
+/// assert_eq!(h2.counter, 1_000_000);
+/// assert_eq!(&h2.message, "greetings");
 ///
-///     let h3: Hello = (-42, "hi".into(), 0usize).into();
-///     assert_eq!(h3.time, -42);
-///     assert_eq!(h3.counter, 0);
-///     assert_eq!(&h3.message, "hi");
-///
-/// }
+/// let h3: Hello = (-42, "hi".into(), 0usize).into();
+/// assert_eq!(h3.time, -42);
+/// assert_eq!(h3.counter, 0);
+/// assert_eq!(&h3.message, "hi");
 /// ```
 ///
 /// ## Structs with non-unique field types
@@ -101,7 +90,7 @@ use {
 ///
 /// Requiring unique types may also be *surprising* behaviour, but is able to
 /// be caught at compile time easily.
-/// 
+///
 /// Also, at the moment of writing, only [`OrderDependentFromTuple`] also derives generic trait implementations
 /// with the caveat that bounds must be only in the where clause.
 #[cfg(feature = "strictly_heterogeneous")]
@@ -121,30 +110,34 @@ pub fn from_strictly_heterogeneous_tuple(input: TokenStream) -> TokenStream {
 
         quote! { #(#impls)* }
     } else {
-        Error::new_spanned(input, "FromStrictlyHeterogeneousTuple currently only supports Struct").to_compile_error()
+        Error::new_spanned(
+            input,
+            "FromStrictlyHeterogeneousTuple currently only supports Struct",
+        )
+        .to_compile_error()
     }
     .into()
 }
 
 /// Derives implementation of [`core::convert::From<(T1,T2,...,Tn)>`][core::convert::From] on `struct`s
 /// whose fields' types are `T1,T2,...,Tn`.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```
 /// use from_tuple::OrderDependentFromTuple;
-/// 
+///
 /// #[derive(OrderDependentFromTuple)]
 /// struct Hello {
 ///     offset: usize,
 ///     len: usize,
 /// }
-/// 
+///
 /// let strukt = Hello::from((234, 16));
 /// assert_eq!(strukt.offset, 234);
 /// assert_eq!(strukt.len, 16);
 /// ```
-/// 
+///
 /// ### [`FromStrictlyHeterogeneousTuple`] vs [`OrderDependentFromTuple`]
 ///
 /// Dependence on order of fields in structs can be *surprising* behaviour as it may accidentally be broken by adding
@@ -152,13 +145,13 @@ pub fn from_strictly_heterogeneous_tuple(input: TokenStream) -> TokenStream {
 ///
 /// Requiring unique types may also be *surprising* behaviour, but is able to
 /// be caught at compile time easily.
-/// 
+///
 /// Also, at the moment of writing, only [`OrderDependentFromTuple`] also derives generic trait implementations
 /// with the caveat that bounds must be only in the where clause
-#[cfg(feature="order_dependent")]
+#[cfg(feature = "order_dependent")]
 #[proc_macro_derive(OrderDependentFromTuple)]
 pub fn derive_from(item: TokenStream) -> TokenStream {
-    use syn::{ItemStruct, Fields, token::Comma};
+    use syn::{token::Comma, Fields, ItemStruct};
 
     let item_struct = parse_macro_input!(item as ItemStruct);
     let fields = match item_struct.fields {
@@ -170,25 +163,27 @@ pub fn derive_from(item: TokenStream) -> TokenStream {
     let where_clause = item_struct.generics.where_clause.as_ref();
     let generics = &item_struct.generics;
     let fields_iter = fields.named.iter();
-    let fields_tys_ts = fields_iter.clone()
-        .map(|f| f.ty.clone())
-        .fold(TokenStream2::new(), |mut ts,ty| {
-            let ty_ts: TokenStream2 = ty.into_token_stream();
-            ts.extend(ty_ts);
-            let comma_ts = Comma::default().into_token_stream();
-            ts.extend(comma_ts);
-            ts
-        });
-    let fields_names_ts = fields_iter
-        .filter_map(|f| f.ident.clone())
-        .fold(TokenStream2::new(), |mut ts,ident| {
-            let ident_ts: TokenStream2 = ident.into_token_stream();
-            ts.extend(ident_ts);
-            let comma_ts = Comma::default().into_token_stream();
-            ts.extend(comma_ts);
-            ts
-        });
-
+    let fields_tys_ts =
+        fields_iter
+            .clone()
+            .map(|f| f.ty.clone())
+            .fold(TokenStream2::new(), |mut ts, ty| {
+                let ty_ts: TokenStream2 = ty.into_token_stream();
+                ts.extend(ty_ts);
+                let comma_ts = Comma::default().into_token_stream();
+                ts.extend(comma_ts);
+                ts
+            });
+    let fields_names_ts =
+        fields_iter
+            .filter_map(|f| f.ident.clone())
+            .fold(TokenStream2::new(), |mut ts, ident| {
+                let ident_ts: TokenStream2 = ident.into_token_stream();
+                ts.extend(ident_ts);
+                let comma_ts = Comma::default().into_token_stream();
+                ts.extend(comma_ts);
+                ts
+            });
 
     let ts: TokenStream2 = quote! {
         impl #generics ::core::convert::From<(#fields_tys_ts)> for #struct_name #generics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,19 @@
 //! Traits transforming types from tuples
 
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
-use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
-use std::collections::HashSet;
-use syn::{parse_macro_input, Data, DeriveInput, Error, Field, Fields};
+use syn::{parse_macro_input, Data, DeriveInput, Error};
 
-/// Derive `From` tuples for `struct`s  that have unique field types.
+mod strictly_heterogeneous;
+
+use strictly_heterogeneous::{impl_from_tuple, permute, verify_unique_field_types};
+
+/// Derives `n!` implementations of [`core::convert::From<...>`][core::convert::From] on `struct`s that have 
+/// unique field types `T1,T2,...,Tn`.
+/// 
+/// More precisely, derives implementations of [`core::convert::From<...>`][core::convert::From]
+/// for all tuples-permuations of `T1,T2,...,Tn`, such as `(T1,T2,...,Tn-1,Tn)`, `(T1,T2,...,Tn,Tn-1)`,
+/// and so on.
 ///
 /// Because of the restriction that field types must be unique, this derive
 /// works best with structs that utilize [newtypes] for data.  Examples of
@@ -16,14 +21,13 @@ use syn::{parse_macro_input, Data, DeriveInput, Error, Field, Fields};
 /// inputs.
 ///
 /// [newtypes]: https://doc.rust-lang.org/rust-by-example/generics/new_types.html
-/// [`From`]: https://doc.rust-lang.org/core/convert/trait.From.html
 ///
 /// # Example
 ///
 /// ```
-/// use from_tuple::FromTuple;
+/// use from_tuple::FromStrictlyHeterogeneousTuple;
 ///
-/// #[derive(FromTuple)]
+/// #[derive(FromStrictlyHeterogeneousTuple)]
 /// struct Hello {
 ///     message: String,
 ///     time: i32,
@@ -49,19 +53,16 @@ use syn::{parse_macro_input, Data, DeriveInput, Error, Field, Fields};
 /// }
 /// ```
 ///
-/// ## Non-unique structs
+/// ## Structs with non-unique field types
 ///
 /// Structs that have non-unique field types will fail to compile.  This is based
-/// on the actual type, and not the alias, so it will fail on e.g. [`c_uchar`]
+/// on the actual type, and not the alias, so it will fail on e.g. [`std::os::raw::c_uchar`]
 /// and [`u8`].
 ///
-/// [`c_uchar`]: https://doc.rust-lang.org/std/os/raw/type.c_uchar.html
-/// [`u8`]: https://doc.rust-lang.org/std/primitive.u8.html
-///
 /// ```compile_fail
-/// use from_tuple::FromTuple;
+/// use from_tuple::FromStrictlyHeterogeneousTuple;
 ///
-/// #[derive(FromTuple)]
+/// #[derive(FromStrictlyHeterogeneousTuple)]
 /// struct NonUnique {
 ///     first: String,
 ///     index: usize,
@@ -72,24 +73,22 @@ use syn::{parse_macro_input, Data, DeriveInput, Error, Field, Fields};
 /// Attempting to compile the previous example will result in
 ///
 /// ```bash
-/// error: Field types must be unique in a struct deriving `FromTuple`
+/// error: Field types must be unique in a struct deriving `FromStrictlyHeterogeneousTuple`
 ///   --> src/lib.rs:41:5
 ///    |
 /// 10 |     second: String,
 ///    |     ^^^^^^^^^^^^^^
 /// ```
 ///
-/// ### Considerations
+/// ### `FromStrictlyHeterogeneousTuple` vs `OrderDependentFromTuple`
 ///
-/// Support for non-unique types is under consideration for a future version,
-/// but has not been implemented because it requires order-dependant fields for
-/// structs - a *surprising* behaviour and can accidentally be broken by adding
+/// Order-dependant fields for structs can be *surprising* behaviour as it may accidentally be broken by adding
 /// a field in the wrong position unknowingly.
 ///
 /// Requiring unique types may also be *surprising* behaviour, but is able to
-/// be caught at compile time easily.  Additionally, I (personally) find it
-/// less *surprising* than it being order-dependant.
-#[proc_macro_derive(FromTuple)]
+/// be caught at compile time easily.
+/// 
+#[proc_macro_derive(FromStrictlyHeterogeneousTuple)]
 pub fn from_tuple(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
@@ -105,100 +104,7 @@ pub fn from_tuple(input: TokenStream) -> TokenStream {
 
         quote! { #(#impls)* }
     } else {
-        Error::new_spanned(input, "FromTuple currently only supports Struct").to_compile_error()
+        Error::new_spanned(input, "FromStrictlyHeterogeneousTuple currently only supports Struct").to_compile_error()
     }
     .into()
-}
-
-/// `impl` `From` for a tuple of field types in the order of the fields passed
-///
-/// If the field types are `String`, `u8`, and `i32`, then the generated `impl`
-/// would be `impl From<(String, u8, i32)> for #struct` where `#struct` is the
-/// `struct` you are deriving on.
-fn impl_from_tuple(fields: &[&Field], data: &DeriveInput) -> TokenStream2 {
-    let struct_ident = &data.ident;
-    let dvars = (0..fields.len())
-        .map(|i| Ident::new(&format!("d{}", i), Span::call_site()))
-        .collect::<Vec<_>>();
-
-    let idents = fields.iter().map(|&f| f.ident.as_ref());
-    let types = fields.iter().map(|&f| &f.ty);
-
-    let tuple_type = quote! { (#(#types),*) };
-    let destructed = quote! { (#(#dvars),*) };
-
-    quote! {
-        impl From<#tuple_type> for #struct_ident {
-
-            #[inline]
-            fn from(tuple: #tuple_type) -> Self {
-                let #destructed = tuple;
-
-                Self {
-                    #(#idents: #dvars),*
-                }
-            }
-        }
-    }
-}
-
-/// Create spanned errors for every non-unique field type
-fn verify_unique_field_types<'a>(fields: &syn::Fields) -> syn::Result<()> {
-    let mut seen = HashSet::new();
-    let mut error = None;
-
-    for field in fields {
-        if !seen.insert(field.ty.clone()) {
-            let new_error = Error::new_spanned(
-                field,
-                "Field types must be unique in a struct deriving `FromTuple`",
-            );
-
-            match error {
-                None => error = Some(new_error),
-                Some(ref mut error) => error.combine(new_error),
-            }
-        }
-    }
-
-    match error {
-        None => Ok(()),
-        Some(error) => Err(error),
-    }
-}
-
-/// Pass all permutations of `syn::Fields` to a callback
-///
-/// Uses an iterative version of [`Heap's Algorithm`] to efficiently generate
-/// all permutations.
-///
-/// [`Heap's Algorithm`]: https://en.wikipedia.org/wiki/Heap%27s_algorithm
-fn permute<F>(fields: &Fields, mut callback: F)
-where
-    F: FnMut(&[&Field]),
-{
-    let mut data = fields.iter().collect::<Vec<_>>();
-
-    // the first permutation is just the unmodified field order
-    callback(&data);
-
-    let mut idx = 0;
-    let mut stack = vec![0; data.len()];
-    while idx < data.len() {
-        if stack[idx] >= idx {
-            stack[idx] = 0;
-            idx += 1;
-        } else {
-            if idx % 2 == 0 {
-                data.swap(0, idx);
-            } else {
-                data.swap(stack[idx], idx);
-            }
-
-            stack[idx] += 1;
-            idx = 0;
-
-            callback(&data);
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-#[doc = include_str!("../README.md")]
+#![doc = include_str!("../README.md")]
+
 #[cfg(any(feature = "strictly_heterogeneous", feature = "order_dependent"))]
 use {proc_macro::TokenStream, quote::quote, syn::parse_macro_input};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,8 @@ use {
 /// Requiring unique types may also be *surprising* behaviour, but is able to
 /// be caught at compile time easily.
 /// 
+/// Also, at the moment of writing, only [`OrderDependentFromTuple`] also derives generic trait implementations
+/// with the caveat that bounds must be only in the where clause.
 #[cfg(feature = "strictly_heterogeneous")]
 #[proc_macro_derive(FromStrictlyHeterogeneousTuple)]
 pub fn from_strictly_heterogeneous_tuple(input: TokenStream) -> TokenStream {
@@ -150,6 +152,9 @@ pub fn from_strictly_heterogeneous_tuple(input: TokenStream) -> TokenStream {
 ///
 /// Requiring unique types may also be *surprising* behaviour, but is able to
 /// be caught at compile time easily.
+/// 
+/// Also, at the moment of writing, only [`OrderDependentFromTuple`] also derives generic trait implementations
+/// with the caveat that bounds must be only in the where clause
 #[cfg(feature="order_dependent")]
 #[proc_macro_derive(OrderDependentFromTuple)]
 pub fn derive_from(item: TokenStream) -> TokenStream {

--- a/src/strictly_heterogeneous.rs
+++ b/src/strictly_heterogeneous.rs
@@ -1,0 +1,97 @@
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
+use quote::quote;
+use std::collections::HashSet;
+use syn::{DeriveInput, Error, Field, Fields};
+
+/// `impl` `From` for a tuple of field types in the order of the fields passed
+///
+/// If the field types are `String`, `u8`, and `i32`, then the generated `impl`
+/// would be `impl From<(String, u8, i32)> for #struct` where `#struct` is the
+/// `struct` you are deriving on.
+pub(super) fn impl_from_tuple(fields: &[&Field], data: &DeriveInput) -> TokenStream2 {
+    let struct_ident = &data.ident;
+    let dvars = (0..fields.len())
+        .map(|i| Ident::new(&format!("d{}", i), Span::call_site()))
+        .collect::<Vec<_>>();
+
+    let idents = fields.iter().map(|&f| f.ident.as_ref());
+    let types = fields.iter().map(|&f| &f.ty);
+
+    let tuple_type = quote! { (#(#types),*) };
+    let destructed = quote! { (#(#dvars),*) };
+
+    quote! {
+        impl From<#tuple_type> for #struct_ident {
+
+            #[inline]
+            fn from(tuple: #tuple_type) -> Self {
+                let #destructed = tuple;
+
+                Self {
+                    #(#idents: #dvars),*
+                }
+            }
+        }
+    }
+}
+
+/// Create spanned errors for every non-unique field type
+pub(super) fn verify_unique_field_types(fields: &syn::Fields) -> syn::Result<()> {
+    let mut seen = HashSet::new();
+    let mut error = None;
+
+    for field in fields {
+        if !seen.insert(field.ty.clone()) {
+            let new_error = Error::new_spanned(
+                field,
+                "Field types must be unique in a struct deriving `FromTuple`",
+            );
+
+            match error {
+                None => error = Some(new_error),
+                Some(ref mut error) => error.combine(new_error),
+            }
+        }
+    }
+
+    match error {
+        None => Ok(()),
+        Some(error) => Err(error),
+    }
+}
+
+/// Pass all permutations of `syn::Fields` to a callback
+///
+/// Uses an iterative version of [`Heap's Algorithm`] to efficiently generate
+/// all permutations.
+///
+/// [`Heap's Algorithm`]: https://en.wikipedia.org/wiki/Heap%27s_algorithm
+pub(super) fn permute<F>(fields: &Fields, mut callback: F)
+where
+    F: FnMut(&[&Field]),
+{
+    let mut data = fields.iter().collect::<Vec<_>>();
+
+    // the first permutation is just the unmodified field order
+    callback(&data);
+
+    let mut idx = 0;
+    let mut stack = vec![0; data.len()];
+    while idx < data.len() {
+        if stack[idx] >= idx {
+            stack[idx] = 0;
+            idx += 1;
+        } else {
+            if idx % 2 == 0 {
+                data.swap(0, idx);
+            } else {
+                data.swap(stack[idx], idx);
+            }
+
+            stack[idx] += 1;
+            idx = 0;
+
+            callback(&data);
+        }
+    }
+}


### PR DESCRIPTION
This PR contains a breaking change. It exposes only `FromStrictlyHeterogeneousTuple` and `OrderDependentFromTuple`, but no `FromTuple`. The reason for that is I'm convinced that populating `n!` implementations shouldn't be the default behavior because it unnecessarily penalizes compile times.

In addition, the users can opt out from any of the derive macros by disabling default features and using only the features they find reasonable.